### PR TITLE
Fix crashing for unknown notification id.

### DIFF
--- a/notifique/src/main/java/com/nathanrassi/notifique/NotifiqueListenerService.kt
+++ b/notifique/src/main/java/com/nathanrassi/notifique/NotifiqueListenerService.kt
@@ -63,12 +63,7 @@ internal class NotificationStore {
     pkg: String,
     id: Int
   ) {
-    val notificationIdList = packageNameToIds[pkg]
-    // Null iff the notification was posted before the listener service was enabled.
-    if (notificationIdList != null) {
-      if (!notificationIdList.remove(id)) {
-        throw IllegalStateException("No notification from package $pkg with id $id was added.")
-      }
-    }
+    // Null or false iff the notification was posted before the listener service was enabled.
+    packageNameToIds[pkg]?.remove(id)
   }
 }

--- a/notifique/src/test/java/com/nathanrassi/notifique/NotificationStoreTest.kt
+++ b/notifique/src/test/java/com/nathanrassi/notifique/NotificationStoreTest.kt
@@ -1,7 +1,6 @@
 package com.nathanrassi.notifique
 
 import com.google.common.truth.Truth.assertThat
-import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -14,20 +13,12 @@ class NotificationStoreTest {
     assertThat(store.addNotificationId("com.example.package", 1)).isFalse()
   }
 
-  @Test fun ignoresRemovingFromUntrackedPackages() {
+  @Test fun removeStopsTrackingNotifiaction() {
     val store = NotificationStore()
+    store.addNotificationId("com.example.package", 1)
+    store.removeNotificationId("com.example.package", 2)
+    assertThat(store.addNotificationId("com.example.package", 1)).isFalse()
     store.removeNotificationId("com.example.package", 1)
-  }
-
-  @Test fun disallowsRemovingWithoutFirstAddingIfPackageIsAlreadyTracked() {
-    val store = NotificationStore()
-    store.addNotificationId("com.example.package", 1) // Tracking the package.
-    try {
-      store.removeNotificationId("com.example.package", 2)
-      fail()
-    } catch (expected: IllegalStateException) {
-      assertThat(expected).hasMessageThat().isEqualTo(
-          "No notification from package com.example.package with id 2 was added.")
-    }
+    assertThat(store.addNotificationId("com.example.package", 1)).isTrue()
   }
 }


### PR DESCRIPTION
A package can be tracked (non-null list value from map) but still have posted a notification before the service started listening to (tracking) notification ids. So, we might get a onNotificationRemoved call with a package we are tracking but a notification id we don't know about.
That's a valid state.