### PR TITLE
Use NotificationManagerCompat for permission check.

### DIFF
--- a/notifique/src/main/res/values/strings.xml
+++ b/notifique/src/main/res/values/strings.xml
@@ -2,4 +2,6 @@
 <resources>
   <string name="label_application">Notifique</string>
   <string name="label_activity">@string/label_application</string>
+  <string name="snackbar"></string>
+  <string name="snackbar_action">Enable Notification Access</string>
 </resources>


### PR DESCRIPTION
And move strings to configuration-dependent resource files.