### PR TITLE
Use round icon resource.

### DIFF
--- a/notifique/src/main/AndroidManifest.xml
+++ b/notifique/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
       android:fullBackupContent="true"
       android:icon="@mipmap/ic_launcher"
       android:label="@string/label_application"
+      android:roundIcon="@mipmap/ic_launcher_round"
       android:supportsRtl="true"
       tools:ignore="GoogleAppIndexingWarning">
     <activity


### PR DESCRIPTION
Round icons are used on Android 7.1 only. Android 8.0+ use the adaptive icons.

This fixes the lint error for the unused resource.
I'd be in favor of removing the round icons, since almost nobody uses them.