### PR TITLE
Fix snackbar reshowing onResume.

### DIFF
--- a/notifique/src/main/java/com/nathanrassi/notifique/NotifiqueActivity.kt
+++ b/notifique/src/main/java/com/nathanrassi/notifique/NotifiqueActivity.kt
@@ -70,7 +70,8 @@ class NotifiqueActivity : AppCompatActivity() {
                 startActivity(intent)
               }
             }
-            setActionTextColor(getColor(R.color.snackbar_action))
+            setTextColor(getColor(R.color.snackbar_text))
+            setActionTextColor(getColor(R.color.snackbar_action_text))
             show()
           }
     } else {

--- a/notifique/src/main/res/values/colors.xml
+++ b/notifique/src/main/res/values/colors.xml
@@ -4,6 +4,7 @@
   <color name="accent">#FFEB3B</color>
   <color name="primary_dark">#457F48</color>
   <color name="toolbar">@color/primary</color>
+  <color name="snackbar_action">#FFFFFF</color>
   <color name="list_item_foreground_selected">#7F4DB6AC</color>
   <color name="scrollbar_background">#CCCCCC</color>
 </resources>

--- a/notifique/src/main/res/values/colors.xml
+++ b/notifique/src/main/res/values/colors.xml
@@ -4,7 +4,8 @@
   <color name="accent">#FFEB3B</color>
   <color name="primary_dark">#457F48</color>
   <color name="toolbar">@color/primary</color>
-  <color name="snackbar_action">#FFFFFF</color>
+  <color name="snackbar_text">@color/accent</color>
+  <color name="snackbar_action_text">@color/accent</color>
   <color name="list_item_foreground_selected">#7F4DB6AC</color>
   <color name="scrollbar_background">#CCCCCC</color>
 </resources>

--- a/notifique/src/main/res/values/strings.xml
+++ b/notifique/src/main/res/values/strings.xml
@@ -3,6 +3,7 @@
   <string name="label_application">Notifique</string>
   <string name="label_activity">@string/label_application</string>
   <string name="snackbar"></string>
+  <string name="snackbar_missing_action">Please go to settings and enable Notification Access</string>
   <string name="snackbar_action">Enable Notification Access</string>
   <string name="toolbar_title">@string/label_application</string>
   <string name="toolbar_delete">Delete</string>


### PR DESCRIPTION
If you pause the window and resume it when the snackbar was showing, the app was dismissing and then reshowing the snackbar which looked broken.
This change removes the action button when the user cannot be sent to the settings app.