### PR TITLE
Fix not handling multiple updates before view update.

### DIFF
--- a/notifique/src/main/java/com/nathanrassi/notifique/NotifiqueListView.kt
+++ b/notifique/src/main/java/com/nathanrassi/notifique/NotifiqueListView.kt
@@ -295,16 +295,27 @@ internal class NotifiqueListView(
       position: Int,
       payloads: List<Any>
     ) {
-      if (payloads.isEmpty()) {
-        onBindViewHolder(holder, position)
-      } else if (
-          payloads.size == 1 && payloads.contains(SelectionTracker.SELECTION_CHANGED_MARKER)
-      ) {
-        val notifique = getItem(position)!!
-        holder.root.isSelected = selectionTracker.isSelected(notifique.id)
-      } else {
-        throw IllegalStateException("Unhandled payloads: $payloads")
+      when {
+        payloads.isEmpty() -> {
+          onBindViewHolder(holder, position)
+        }
+        payloads.containsOnly(SelectionTracker.SELECTION_CHANGED_MARKER) -> {
+          val notifique = getItem(position)!!
+          holder.root.isSelected = selectionTracker.isSelected(notifique.id)
+        }
+        else -> {
+          throw IllegalStateException("Unhandled payloads: $payloads")
+        }
       }
+    }
+
+    private fun List<Any>.containsOnly(element: Any): Boolean {
+      for (i in indices) {
+        if (this[i] != element) {
+          return false
+        }
+      }
+      return true
     }
 
     private class ViewHolder(val root: ItemView) : RecyclerView.ViewHolder(root)


### PR DESCRIPTION
Closes #59.

As stated there, this crash occurred when multiple selection changes happened before the view was ready to be updated (and the bind method was called).